### PR TITLE
Updates according to Chocolatey Guidelines

### DIFF
--- a/metanorma.nuspec
+++ b/metanorma.nuspec
@@ -5,25 +5,29 @@
     <id>metanorma</id>
     <version>1.1.4</version>
     <owners>ribose</owners>
-    <title>metanorma</title>
+    <title>Metanorma</title>
     <authors>Ribose Inc.</authors>
+    <iconUrl>https://open.ribose.com/projects/Metanorma/assets/symbol.svg</iconUrl>
     <projectUrl>https://www.metanorma.com/</projectUrl>
     <copyright>2019 Ribose Inc.</copyright>
     <licenseUrl>https://raw.githubusercontent.com/riboseinc/metanorma-windows-setup/master/LICENSE.adoc</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/riboseinc/chocolatey-metanorma</projectSourceUrl>
+    <packageSourceUrl>https://github.com/riboseinc/chocolatey-metanorma</packageSourceUrl>
+    <releaseNotes>https://github.com/riboseinc/metanorma/releases</releaseNotes>
     <docsUrl>https://www.metanorma.com/docs/getting-started/</docsUrl>
     <bugTrackerUrl>https://github.com/riboseinc/chocolatey-metanorma/issues</bugTrackerUrl>
     <tags>metanorma documentation generator</tags>
+    <summary>The standard of standards</summary>
     <description><![CDATA[**Metanorma** an open-source framework for writing and publishing standards documents with a focus on semantic authoring and flexible output support. Here’s what you can do with Metanorma: 
  - Build tools for authoring standards and formatting them in accordance with your organization’s practices
  - Use the existing processor ecosystem to create documents compliant to the requirements of ISO, RFC, CalConnect, and others.]]></description>
     <dependencies>
-      <dependency id="msys2" />
+      <dependency id="msys2" version="20180531.0.0" />
       <dependency id="ruby" version="(,2.6.0)" />
-      <dependency id="xsltproc" />
+      <dependency id="xsltproc" version="1.1.28.0" />
       <dependency id="nodejs" version="11.3.0" />
-      <dependency id="plantuml" />
+      <dependency id="plantuml" version="1.2018.14" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
 - Package contains dependencies with no specified version. You should at least specify a minimum version of a dependency.
 - The iconUrl should be added if there is one. Please correct this in the nuspec, if applicable.
 - The nuspec has been enhanced to allow packageSourceUrl, pointing to the url where the package source resides. This is a strong guideline because it simplifies collaboration. Please add it to the nuspec.
 - Release Notes (releaseNotes) are a short description of changes in each version of a package. Please include releasenotes in the nuspec. NOTE: To prevent the need to continually update this field, providing a URL to an external list of Release Notes is perfectly acceptable.
 - Summary (summary) is a short explanation of the software. Please include summary in the nuspec. More...
 - Title (title) matches id exactly. Please consider using something slightly more descriptive for the title in the nuspec.